### PR TITLE
feat(src/PoseNet/index.js): Ability to access parts of pose by name.

### DIFF
--- a/src/PoseNet/index.js
+++ b/src/PoseNet/index.js
@@ -61,10 +61,22 @@ class PoseNet extends EventEmitter {
     return posenet.getAdjacentKeyPoints(keypoints, confidence);
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  mapParts(pose) {
+    const newPose = JSON.parse(JSON.stringify(pose));
+    newPose.keypoints.forEach((keypoint) => {
+      newPose[keypoint.part] = {
+        x: keypoint.position.x,
+        y: keypoint.position.y,
+        confidence: keypoint.score,
+      };
+    });
+    return newPose;
+  }
+
   /* eslint max-len: ["error", { "code": 180 }] */
   async singlePose(inputOr) {
     let input;
-
     if (inputOr instanceof HTMLImageElement || inputOr instanceof HTMLVideoElement) {
       input = inputOr;
     } else if (typeof inputOr === 'object' && (inputOr.elt instanceof HTMLImageElement || inputOr.elt instanceof HTMLVideoElement)) {
@@ -74,7 +86,8 @@ class PoseNet extends EventEmitter {
     }
 
     const pose = await this.net.estimateSinglePose(input, this.imageScaleFactor, this.flipHorizontal, this.outputStride);
-    const result = [{ pose, skeleton: this.skeleton(pose.keypoints) }];
+    const poseWithParts = this.mapParts(pose);
+    const result = [{ poseWithParts, skeleton: this.skeleton(pose.keypoints) }];
     this.emit('pose', result);
     if (this.video) {
       return tf.nextFrame().then(() => this.singlePose());
@@ -94,7 +107,8 @@ class PoseNet extends EventEmitter {
     }
 
     const poses = await this.net.estimateMultiplePoses(input, this.imageScaleFactor, this.flipHorizontal, this.outputStride);
-    const result = poses.map(pose => ({ pose, skeleton: this.skeleton(pose.keypoints) }));
+    const posesWithParts = poses.map(pose => (this.mapParts(pose)));
+    const result = posesWithParts.map(pose => ({ pose, skeleton: this.skeleton(pose.keypoints) }));
     this.emit('pose', result);
     if (this.video) {
       return tf.nextFrame().then(() => this.multiPose());
@@ -129,5 +143,4 @@ const poseNet = (videoOrOptionsOrCallback, optionsOrCallback, cb) => {
 
   return new PoseNet(video, options, detectionType, callback);
 };
-
 export default poseNet;


### PR DESCRIPTION
Now can simply do pose.nose.x or pose.nose.confidence. Using original PoseNet naming scheme (i.e.
rightShoulder).

re #245